### PR TITLE
Fix logout link

### DIFF
--- a/wollburger/includes/menu.php
+++ b/wollburger/includes/menu.php
@@ -42,7 +42,7 @@
   </ul>
   <?php if (isset($_SESSION['admin_user'])): ?>
     <div class="absolute bottom-0 w-full">
-      <a href="/logout.php"
+      <a href="/wollburger/logout.php"
          class="block px-4 py-2 text-red-400 hover:bg-gray-700 hover:text-red-200">
         Logout
       </a>

--- a/wollburger/logout.php
+++ b/wollburger/logout.php
@@ -2,5 +2,5 @@
 session_start();
 session_unset();
 session_destroy();
-header('Location: /login.php');
+header('Location: /wollburger/login.php');
 exit;


### PR DESCRIPTION
## Summary
- correct logout link in `menu.php`
- redirect logout back to login page with the proper path

## Testing
- `php -l wollburger/includes/menu.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684852d5afa8832e953698caeae5476a