### PR TITLE
Fix nullable slug causing deprecation warning in Auth

### DIFF
--- a/multi-menu/app/core/Auth.php
+++ b/multi-menu/app/core/Auth.php
@@ -53,7 +53,7 @@ class Auth {
   /* ========= Contexto de Empresa Ativa (para root trocar de empresa) ========= */
 
   /** Define o contexto de empresa ativa (também útil para owner/staff) */
-  public static function setActiveCompany(int $companyId, string $slug = null): void {
+  public static function setActiveCompany(int $companyId, ?string $slug = null): void {
     $_SESSION['active_company_id'] = $companyId;
     if ($slug !== null) {
       $_SESSION['active_company_slug'] = $slug;


### PR DESCRIPTION
## Summary
- Declare slug parameter in Auth::setActiveCompany as nullable to avoid deprecation warnings and session start errors

## Testing
- `php -l app/core/Auth.php`
- `curl -i http://127.0.0.1:8000/admin/wollburger/orders`


------
https://chatgpt.com/codex/tasks/task_e_68b765472cb0832e9576acd8a8198570